### PR TITLE
Added CLI tool 

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,38 @@
+# perm CLI tool
+
+## Usage
+
+At the moment it only supports node operations:
+```
+perm node <command>
+
+Manage nodes
+
+Commands:
+  perm node add <enode>     Add <enode> to allowlist
+  perm node list            list all nodes
+  perm node remove <enode>  Remove <enode> from allowlist
+
+Options:
+  --version           Show version number                              [boolean]
+  --host, -H          Ethereum host                                   [required]
+  --from, -a          Ethereum Account to run transactions
+  --node-ingress, -n  Node Ingress Contract Address                   [required]
+  --help              Show help                                        [boolean]
+```
+
+### Node connection details
+The easiest way to use the tool is by exporting these envvar:
+
+```
+PERM_FROM=0xFE3B557E8Fb62b89F4916B721be55cEb828dBd73
+PERM_HOST=http://phoenixnet-ethsigner.k8s.dev.adhara.zone:80
+PERM_NODE_INGRESS=0xfE0B7EE21e8298fC68b9Bf5f404e7df7B6671EC2
+```
+
+## Installation
+* pull this repo
+* `npm install`
+* `npm run build:contracts` (smart contracts need to be compiled)
+* `npm link` (creates a symbolic link in your $PATH to the cli tool script)
+

--- a/cli/cmds/node.js
+++ b/cli/cmds/node.js
@@ -1,0 +1,6 @@
+exports.command = 'node <command>'
+exports.description = 'Manage nodes'
+exports.builder = function (yargs) {
+  return yargs.commandDir('node_cmds')
+}
+exports.handler = function (argv) {}

--- a/cli/cmds/node_cmds/add.js
+++ b/cli/cmds/node_cmds/add.js
@@ -1,0 +1,24 @@
+const  Web3 = require("web3")
+const enodeLib = require("../../lib/enode.js")
+
+exports.command = 'add <enode>'
+exports.desc = 'Add <enode> to allowlist'
+exports.builder = {}
+
+exports.handler = async (argv) => {
+  try {
+    nr = await require("../../lib/setup.js").nodeRules(argv)
+
+    enode = enodeLib.utils.parse(argv.enode)
+
+    tx = await nr.addEnode(enode.enodeHigh, enode.enodeLow, Web3.utils.stringToHex(enode.hostname), enode.port)
+
+    if (tx.receipt && tx.receipt.status) {
+      console.log("Added")
+    } else {
+      throw new Error("error, check tx: " + tx.hash)
+    }
+  } catch (err) {
+    throw err
+  }
+}

--- a/cli/cmds/node_cmds/list.js
+++ b/cli/cmds/node_cmds/list.js
@@ -1,0 +1,20 @@
+const enodeLib = require("../../lib/enode.js")
+
+exports.command = 'list'
+exports.desc = 'list all nodes'
+exports.builder = {}
+
+exports.handler = async function (argv) {
+  try {
+    nr = await require("../../lib/setup.js").nodeRules(argv)
+
+    size = await nr.getSize()
+    for (var i = 0; i < size.toNumber(); i++) {
+      enode = await nr.getByIndex(i)
+
+      console.log(enodeLib.utils.toString(enode))
+    }
+  } catch (err) {
+	console.log(err)
+  }
+}

--- a/cli/cmds/node_cmds/remove.js
+++ b/cli/cmds/node_cmds/remove.js
@@ -1,8 +1,8 @@
 const  Web3 = require("web3")
 const enodeLib = require("../../lib/enode.js")
 
-exports.command = 'add <enode>'
-exports.desc = 'Add <enode> to allowlist'
+exports.command = 'remove <enode>'
+exports.desc = 'Remove <enode> from allowlist'
 exports.builder = {}
 
 exports.handler = async (argv) => {
@@ -11,10 +11,10 @@ exports.handler = async (argv) => {
 
     enode = enodeLib.utils.parse(argv.enode)
 
-    tx = await nr.addEnode(enode.enodeHigh, enode.enodeLow, enode.hostname, enode.port)
+    tx = await nr.removeEnode(enode.enodeHigh, enode.enodeLow, enode.hostname, enode.port)
 
     if (tx.receipt && tx.receipt.status) {
-      console.log("Added")
+      console.log("Removed")
     } else {
       throw new Error("error, check tx: " + tx.hash)
     }

--- a/cli/index.js
+++ b/cli/index.js
@@ -13,8 +13,8 @@ require('yargs')
        required: false,
        alias: 'a',
      },
-     'node-rules-contract': {
-       description: 'Node Rules Contract Address',
+     'node-ingress': {
+       description: 'Node Ingress Contract Address',
        required: true,
        alias: 'n',
      },

--- a/cli/index.js
+++ b/cli/index.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+require('yargs')
+  .env("PERM")
+  .commandDir('cmds')
+  .options({
+     'host': {
+       description: 'Ethereum host',
+       required: true,
+       alias: 'H',
+     },
+     'from': {
+       description: 'Ethereum Account to run transactions',
+       required: false,
+       alias: 'a',
+     },
+     'node-rules-contract': {
+       description: 'Node Rules Contract Address',
+       required: true,
+       alias: 'n',
+     },
+   })
+  .demandCommand()
+  .help()
+  .argv

--- a/cli/lib/enode.js
+++ b/cli/lib/enode.js
@@ -4,7 +4,7 @@ exports.utils = {
   toString: (enode) => {
     enodeHigh = enode.enodeHigh.substring(2)
     enodeLow = enode.enodeLow.substring(2)
-    ip = Web3.utils.hexToString(enode.ip)
+    ip = hexToIp(enode.ip)
     port = enode.port.toNumber()
     return `enode://${enodeHigh}${enodeLow}@${ip}:${port}`
   },
@@ -14,11 +14,54 @@ exports.utils = {
     pub = url.username
 
     return {
+      originalUrl: url,
       enodeHigh: '0x' + pub.substring(0, pub.length/2),
       enodeLow: '0x' + pub.substring(pub.length/2),
-      hostname: url.hostname,
+      hostname: getHexIpv4(url.hostname),
       port: url.port
     }
   }
 }
 
+function getHexIpv4(stringIp) {
+  const splitIp = stringIp.split('.');
+  return `0x00000000000000000000ffff${toHex(splitIp[0])}${toHex(splitIp[1])}${toHex(splitIp[2])}${toHex(splitIp[3])}`;
+}
+
+function toHex(number) {
+  const num = Number(number).toString(16);
+  return num.length < 2 ? `0${num}` : num;
+}
+
+const ipv4Prefix = '00000000000000000000ffff';
+
+const hexToIp = (address) => {
+  address = address.split('x')[1];
+  return isIpv4(address) ? getIpv4(address) : getIpv6(address);
+};
+
+const isIpv4 = (address) => {
+  return address.startsWith(ipv4Prefix) && parseInt(address.substring(ipv4Prefix.length), 16) <= 0xffffffff;
+};
+
+const getIpv4 = (address) => {
+  return splitAddress(address.split(ipv4Prefix)[1], 2)
+    .map(hex => {
+      return parseInt(hex, 16);
+    })
+    .join('.');
+};
+
+const getIpv6 = (address) => {
+  return splitAddress(address, 4).join(':');
+};
+
+const splitAddress = (address, digits) => {
+  const bits = [];
+
+  while (address.length >= digits) {
+    bits.push(address.slice(0, digits));
+    address = address.slice(digits);
+  }
+  return bits;
+};

--- a/cli/lib/enode.js
+++ b/cli/lib/enode.js
@@ -1,0 +1,24 @@
+const  Web3 = require("web3")
+
+exports.utils = {
+  toString: (enode) => {
+    enodeHigh = enode.enodeHigh.substring(2)
+    enodeLow = enode.enodeLow.substring(2)
+    ip = Web3.utils.hexToString(enode.ip)
+    port = enode.port.toNumber()
+    return `enode://${enodeHigh}${enodeLow}@${ip}:${port}`
+  },
+
+  parse: (enodeUrl) => {
+    url = new URL(enodeUrl)
+    pub = url.username
+
+    return {
+      enodeHigh: '0x' + pub.substring(0, pub.length/2),
+      enodeLow: '0x' + pub.substring(pub.length/2),
+      hostname: url.hostname,
+      port: url.port
+    }
+  }
+}
+

--- a/cli/lib/setup.js
+++ b/cli/lib/setup.js
@@ -2,6 +2,7 @@ const contract = require('@truffle/contract')
 const  Web3 = require("web3")
 
 const NodeRules = contract(require('../../src/chain/abis/NodeRules.json'))
+const NodeIngress = contract(require('../../src/chain/abis/NodeIngress.json'))
 
 exports.nodeRules = async (argv) => {
   let provider = new Web3.providers.HttpProvider(argv.host)
@@ -9,5 +10,12 @@ exports.nodeRules = async (argv) => {
   NodeRules.defaults({
     from: argv.from,
   })
-  return await NodeRules.at(argv.nodeRulesContract)
+  NodeIngress.setProvider(provider)
+  NodeIngress.defaults({
+    from: argv.from,
+  })
+
+  ni = await NodeIngress.at(argv.nodeIngress)
+  rules = await ni.getContractAddress(Web3.utils.stringToHex("rules"))
+  return await NodeRules.at(rules)
 }

--- a/cli/lib/setup.js
+++ b/cli/lib/setup.js
@@ -1,0 +1,13 @@
+const contract = require('@truffle/contract')
+const  Web3 = require("web3")
+
+const NodeRules = contract(require('../../src/chain/abis/NodeRules.json'))
+
+exports.nodeRules = async (argv) => {
+  let provider = new Web3.providers.HttpProvider(argv.host)
+  NodeRules.setProvider(provider)
+  NodeRules.defaults({
+    from: argv.from,
+  })
+  return await NodeRules.at(argv.nodeRulesContract)
+}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "name": "permissioning-smart-contracts",
+  "bin": {
+    "perm": "./cli/index.js"
+  },
   "repository": "permissioning-smart-contracts",
   "license": "Apache-2.0",
   "private": true,
@@ -40,6 +43,7 @@
     ]
   },
   "dependencies": {
+    "@truffle/contract": "^4.2.20",
     "@types/classnames": "^2.2.8",
     "@types/enzyme": "^3.9.3",
     "@types/enzyme-adapter-react-16": "^1.0.5",
@@ -63,7 +67,8 @@
     "truffle-hdwallet-provider": "^1.0.17",
     "typescript": "^3.5.1",
     "web3": "1.2.5",
-    "web3-utils": "^1.0.0-beta.52"
+    "web3-utils": "^1.0.0-beta.52",
+    "yargs": "^15.4.1"
   },
   "devDependencies": {
     "enzyme": "^3.9.0",


### PR DESCRIPTION
## Usage

At the moment it only supports node operations:
```
perm node <command>

Manage nodes

Commands:
  perm node add <enode>     Add <enode> to allowlist
  perm node list            list all nodes
  perm node remove <enode>  Remove <enode> from allowlist

Options:
  --version           Show version number                              [boolean]
  --host, -H          Ethereum host                                   [required]
  --from, -a          Ethereum Account to run transactions
  --node-ingress, -n  Node Ingress Contract Address                   [required]
  --help              Show help                                        [boolean]
```

### Node connection details
The easiest way to use the tool is by exporting these envvar:

```
PERM_FROM=0xFE3B557E8Fb62b89F4916B721be55cEb828dBd73
PERM_HOST=http://phoenixnet-ethsigner.k8s.dev.adhara.zone:80
PERM_NODE_INGRESS=0xfE0B7EE21e8298fC68b9Bf5f404e7df7B6671EC2
```

## Installation
* pull this repo
* `npm install`
* `npm link` (creates a symbolic link in your $PATH to the cli tool script)
